### PR TITLE
【再履修】lsコマンドを作る2 ( `-a` オプション)

### DIFF
--- a/15.ls_again/lib/ls.rb
+++ b/15.ls_again/lib/ls.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+
 require 'optparse'
 
 def find(dir, hidden_files)
@@ -39,7 +40,7 @@ end
 COLUMNS = 3
 
 if __FILE__ == $PROGRAM_NAME
-  options = ARGV.getopts('a')
+  options    = ARGV.getopts('a')
   target     = ARGV.empty? ? '.' : ARGV[0]
   display(format(transpose(find(target, options['a']), COLUMNS)))
 end

--- a/15.ls_again/lib/ls.rb
+++ b/15.ls_again/lib/ls.rb
@@ -4,10 +4,11 @@
 require 'optparse'
 
 def find(dir, hidden_files)
+  files = Dir.foreach(dir).sort
   if hidden_files
-    Dir.foreach(dir).sort
+    files
   else
-    Dir.foreach(dir).reject { |f| f.start_with?('.') }.sort
+    files.reject { |f| f.start_with?('.') }
   end
 end
 

--- a/15.ls_again/lib/ls.rb
+++ b/15.ls_again/lib/ls.rb
@@ -1,8 +1,13 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+require 'optparse'
 
-def find(dir)
-  Dir.foreach(dir).reject { |f| f.start_with?('.') }.sort
+def find(dir, hidden_files)
+  if hidden_files
+    Dir.foreach(dir).sort
+  else
+    Dir.foreach(dir).reject { |f| f.start_with?('.') }.sort
+  end
 end
 
 def transpose(files, cols_count)
@@ -34,6 +39,7 @@ end
 COLUMNS = 3
 
 if __FILE__ == $PROGRAM_NAME
+  options = ARGV.getopts('a')
   target     = ARGV.empty? ? '.' : ARGV[0]
-  display(format(transpose(find(target), COLUMNS)))
+  display(format(transpose(find(target, options['a']), COLUMNS)))
 end

--- a/15.ls_again/test/ls_test.rb
+++ b/15.ls_again/test/ls_test.rb
@@ -87,7 +87,7 @@ class LsTest < Minitest::Test
     assert_output(expected) { display(format(transpose(find(target, false), COLUMNS))) }
   end
 
-  def a_option
+  def test_a_option
     target   = File.join(TEST_DIR, 'long_file_name')
     expected = <<~TEXT
       .               dir             test-dir1

--- a/15.ls_again/test/ls_test.rb
+++ b/15.ls_again/test/ls_test.rb
@@ -11,7 +11,7 @@ class LsTest < Minitest::Test
     expected = <<~TEXT
       1
     TEXT
-    assert_output(expected) { display(format(transpose(find(target), COLUMNS))) }
+    assert_output(expected) { display(format(transpose(find(target, false), COLUMNS))) }
   end
 
   def test_2_files
@@ -19,7 +19,7 @@ class LsTest < Minitest::Test
     expected = <<~TEXT
       1 2
     TEXT
-    assert_output(expected) { display(format(transpose(find(target), COLUMNS))) }
+    assert_output(expected) { display(format(transpose(find(target, false), COLUMNS))) }
   end
 
   def test_3_files
@@ -27,7 +27,7 @@ class LsTest < Minitest::Test
     expected = <<~TEXT
       1 2 3
     TEXT
-    assert_output(expected) { display(format(transpose(find(target), COLUMNS))) }
+    assert_output(expected) { display(format(transpose(find(target, false), COLUMNS))) }
   end
 
   def test_4_files
@@ -36,7 +36,7 @@ class LsTest < Minitest::Test
       1 3
       2 4
     TEXT
-    assert_output(expected) { display(format(transpose(find(target), COLUMNS))) }
+    assert_output(expected) { display(format(transpose(find(target, false), COLUMNS))) }
   end
 
   def test_5_files
@@ -45,7 +45,7 @@ class LsTest < Minitest::Test
       1 3 5
       2 4
     TEXT
-    assert_output(expected) { display(format(transpose(find(target), COLUMNS))) }
+    assert_output(expected) { display(format(transpose(find(target, false), COLUMNS))) }
   end
 
   def test_6_files
@@ -54,7 +54,7 @@ class LsTest < Minitest::Test
       1 3 5
       2 4 6
     TEXT
-    assert_output(expected) { display(format(transpose(find(target), COLUMNS))) }
+    assert_output(expected) { display(format(transpose(find(target, false), COLUMNS))) }
   end
 
   def test_7_files
@@ -64,7 +64,7 @@ class LsTest < Minitest::Test
       2 5
       3 6
     TEXT
-    assert_output(expected) { display(format(transpose(find(target), COLUMNS))) }
+    assert_output(expected) { display(format(transpose(find(target, false), COLUMNS))) }
   end
 
   def test_8_files
@@ -74,7 +74,7 @@ class LsTest < Minitest::Test
       2 5 8
       3 6
     TEXT
-    assert_output(expected) { display(format(transpose(find(target), COLUMNS))) }
+    assert_output(expected) { display(format(transpose(find(target, false), COLUMNS))) }
   end
 
   def test_various_file_names
@@ -84,6 +84,6 @@ class LsTest < Minitest::Test
       esa             ls.rb           test-dir2_copy
       folder          test-dir1       test-dir2_copy2
     TEXT
-    assert_output(expected) { display(format(transpose(find(target), COLUMNS))) }
+    assert_output(expected) { display(format(transpose(find(target, false), COLUMNS))) }
   end
 end

--- a/15.ls_again/test/ls_test.rb
+++ b/15.ls_again/test/ls_test.rb
@@ -86,4 +86,16 @@ class LsTest < Minitest::Test
     TEXT
     assert_output(expected) { display(format(transpose(find(target, false), COLUMNS))) }
   end
+
+  def a_option
+    target   = File.join(TEST_DIR, 'long_file_name')
+    expected = <<~TEXT
+      .               dir             test-dir1
+      ..              esa             test-dir2
+      .DS_Store       folder          test-dir2_copy
+      .gitkeep        gb              test-dir2_copy2
+      .vscode         ls.rb
+    TEXT
+    assert_output(expected) { display(format(transpose(find(target, true), COLUMNS))) }
+  end
 end


### PR DESCRIPTION
まただいぶ間が空いてしまいましたが、前回からの続きでテスト込みのlsコマンドの`-a`オプションを実装してみました
レビューよろしくお願いします 🙇🏼 

- [lsコマンドを作る2 | FBC](https://bootcamp.fjord.jp/products/13374)
    - 以前やったlsコマンド2: [lsコマンドを作る2 ( `-a` オプション) by taea · Pull Request #7 · taea/ruby-practices](https://github.com/taea/ruby-practices/pull/7)
    - 前回のテスト込みのlsコマンド1: [【再履修】lsコマンドを作る1 by taea · Pull Request #9 · taea/ruby-practices](https://github.com/taea/ruby-practices/pull/9)

## スクショ

### プログラム実行結果

`cd ruby-practices`
`15.ls_again/lib/ls.rb -a 15.ls_again/test/ls-sample/long_file_name/`

<img width="917" alt="image" src="https://github.com/taea/ruby-practices/assets/341101/4fa2307e-6fd7-43cc-921a-6f1ace8d6441">


### Mac OS標準のlsコマンド

`/bin/ls -a 15.ls_again/test/ls-sample/long_file_name/`

<img width="384" alt="image" src="https://github.com/taea/ruby-practices/assets/341101/682f92fc-6d68-495d-9c8a-d6407d263678">

### rubocop

<img width="794" alt="image" src="https://github.com/taea/ruby-practices/assets/341101/079bffd5-d243-4690-8585-506f29164e9b">

※テスト用に置いたrbファイルの中身が空で検知されていますが、今回は無視しました

### minitest

<img width="713" alt="image" src="https://github.com/taea/ruby-practices/assets/341101/e4f666c2-c2d2-4bed-a3ee-d1a030c2134c">
