### PR TITLE
【再履修】lsコマンドを作る3（`-r`オプション）

### DIFF
--- a/15.ls_again/lib/ls.rb
+++ b/15.ls_again/lib/ls.rb
@@ -12,6 +12,14 @@ def find(dir, hidden_files)
   end
 end
 
+def order(files, reverse)
+  if reverse
+    files.reverse
+  else
+    files
+  end
+end
+
 def transpose(files, cols_count)
   rows_count = (files.length.to_f / cols_count).ceil
   col_matrix = files.each_slice(rows_count).to_a
@@ -41,7 +49,7 @@ end
 COLUMNS = 3
 
 if __FILE__ == $PROGRAM_NAME
-  options    = ARGV.getopts('a')
+  options    = ARGV.getopts('a', 'r')
   target     = ARGV.empty? ? '.' : ARGV[0]
-  display(format(transpose(find(target, options['a']), COLUMNS)))
+  display(format(transpose(order(find(target, options['a']), options['r']), COLUMNS)))
 end

--- a/15.ls_again/test/ls_test.rb
+++ b/15.ls_again/test/ls_test.rb
@@ -98,4 +98,26 @@ class LsTest < Minitest::Test
     TEXT
     assert_output(expected) { display(format(transpose(find(target, true), COLUMNS))) }
   end
+
+  def test_r_option
+    target   = File.join(TEST_DIR, 'long_file_name')
+    expected = <<~TEXT
+      test-dir2_copy2 test-dir1       folder
+      test-dir2_copy  ls.rb           esa
+      test-dir2       gb              dir
+    TEXT
+    assert_output(expected) { display(format(transpose(order(find(target, false), true), COLUMNS))) }
+  end
+
+  def test_ar_option
+    target   = File.join(TEST_DIR, 'long_file_name')
+    expected = <<~TEXT
+      test-dir2_copy2 gb              .gitkeep
+      test-dir2_copy  folder          .DS_Store
+      test-dir2       esa             ..
+      test-dir1       dir             .
+      ls.rb           .vscode
+    TEXT
+    assert_output(expected) { display(format(transpose(order(find(target, true), true), COLUMNS))) }
+  end
 end


### PR DESCRIPTION
@cafedomancer 毎度お世話になり、ありがとうございます！:bow: また、レビューをよろしくお願いいたします :pray:

rubocop で出た警告に関して、1つ質問があります。詳細は以下のスクショの rubocop の欄に書きましたので、ご確認ください 🙏🏼 

提出物ページ: [lsコマンドを作る3 | FBC](https://bootcamp.fjord.jp/products/13531)

# スクショ

## プログラム実行結果

`cd ruby-practices`

### `-r`オプション

`15.ls_again/lib/ls.rb -r 15.ls_again/test/ls-sample/long_file_name/`

<img width="938" alt="image" src="https://github.com/taea/ruby-practices/assets/341101/b4bacfcc-a633-4d8e-b107-ae688935abf7">

### `-ar`オプション

`15.ls_again/lib/ls.rb -ar 15.ls_again/test/ls-sample/long_file_name/`

<img width="941" alt="image" src="https://github.com/taea/ruby-practices/assets/341101/540c5711-6d71-44a9-aef9-40ffe8129a5a">

## Mac OSの標準コマンド

`/bin/ls -r 15.ls_again/test/ls-sample/long_file_name/`

<img width="391" alt="image" src="https://github.com/taea/ruby-practices/assets/341101/7caee849-cca3-4489-807b-5165068b925a">

## rubocop

質問: 以前のテスト用に置いていた空ファイルの.rbへの警告に加え、テスト用のClassの行数が多すぎるとの警告が出ました。
しかし、テストケースを網羅するのには行数はある程度必要かと思うので、こういった場合は無視しちゃっても良いでしょうか？？

<img width="860" alt="image" src="https://github.com/taea/ruby-practices/assets/341101/1463e981-0cc6-4300-91c5-78c4ccbad90a">


## minitest

<img width="695" alt="image" src="https://github.com/taea/ruby-practices/assets/341101/f071cd1b-2cb7-448c-8518-c0ebed1796e5">
